### PR TITLE
fix: add correct debian dependencies and add debian install script

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -77,10 +77,10 @@ jobs:
             -v "${PACKAGE_AUTOPSY_BIN_VERSION}" \
             --iteration "$PACKAGE_SLEUTHKIT_JAVA_REL" \
             --no-auto-depends \
-            -d "openjdk-8-jre" \
+            -d "bellsoft-java8-full" \
             -d "sleuthkit-java (>= ${PACKAGE_SLEUTHKIT_JAVA_VERSION})" \
             -d "testdisk" \
-            -d "openjfx" \
+            -d "imagemagick" \
             -a amd64 \
             -s pacman autopsy-bin-${PACKAGE_AUTOPSY_BIN_VERSION}-${PACKAGE_AUTOPSY_BIN_REL}-x86_64.pkg.tar.zst
           mkdir -p /tmp/artifacts

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Automatic Github Workflows packager for autopsy
 
 ## Installation
 
+Right now the built packages are only available under the CI artifacts. Check out the latest CI build of the matching package version and download the artifacts from there.
+
+### Arch Linux
+
 Be sure to have the following requirements before starting any installation process of Autopsy:
 
 * sleuthkit-java
 * openjdk8-jre
-
-Right now the built packages are only available under the CI artifacts. Check out the latest CI build of the matching package version and download the artifacts from there.
-
-### Arch Linux
 
 If you have an AUR helper, you just need to choose to install either `autopsy` or `autopsy-bin` packages.
 
@@ -26,10 +26,19 @@ sudo pacman -U <package-name>.pkg.tar.zst
 
 ### Debian
 
-```bash
-sudo apt install <package-name>.deb
-```
+#### Automatic installation via install script
 
-The Sleuth Kit package .deb files:
+The script below will install autopsy and its dependencies, including bellsoft's java jre version 8. Inspect [the script](install_debian_autopsy_4.19.2.sh) before installing, and make sure you are comfortable running it.
 
-- Autopsy 4.9.2 -> [The Sleuth Kit 4.11.1](https://github.com/sleuthkit/sleuthkit/releases/download/sleuthkit-4.11.1/sleuthkit-java_4.11.1-1_amd64.deb)
+Note, the script will ask for the user password in order to use sudo.
+
+Copy the code below and paste on a terminal window.
+
+- Autopsy 4.19.2: `curl https://raw.githubusercontent.com/labcif/autopsy-packager/main/install_debian_autopsy_4.19.2.sh | sudo bash`
+
+#### Sleuth Kit versions associated with each release of autopsy:
+
+- Autopsy 4.17.0 -> [The Sleuth Kit 4.10.1](https://github.com/sleuthkit/sleuthkit/releases/download/sleuthkit-4.10.1/sleuthkit-java_4.10.1-1_amd64.deb)
+- Autopsy 4.18.0 -> [The Sleuth Kit 4.10.2](https://github.com/sleuthkit/sleuthkit/releases/download/sleuthkit-4.10.2/sleuthkit-java_4.10.2-1_amd64.deb)
+- Autopsy 4.19.1 -> [The Sleuth Kit 4.11.0](https://github.com/sleuthkit/sleuthkit/releases/download/sleuthkit-4.11.0/sleuthkit-java_4.11.0-1_amd64.deb)
+- Autopsy 4.19.2 -> [The Sleuth Kit 4.11.1](https://github.com/sleuthkit/sleuthkit/releases/download/sleuthkit-4.11.1/sleuthkit-java_4.11.1-1_amd64.deb)

--- a/install_debian_autopsy_4.19.2.sh
+++ b/install_debian_autopsy_4.19.2.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+cd "$(mktemp -d -t autopsy_installer-XXXXXXXXXX)"
+
+apt -y update
+apt -y install curl gnupg
+
+curl -OL https://github.com/sleuthkit/sleuthkit/releases/download/sleuthkit-4.11.1/sleuthkit-java_4.11.1-1_amd64.deb
+curl -OL https://github.com/labcif/autopsy-packager/releases/download/4.19.2-1/autopsy_4.19.2-1_amd64.deb
+
+curl https://download.bell-sw.com/pki/GPG-KEY-bellsoft | apt-key add -
+echo "deb [arch=amd64] https://apt.bell-sw.com/ stable main" > /etc/apt/sources.list.d/bellsoft.list
+
+apt -y update
+
+apt -y install ./sleuthkit-java_4.11.1-1_amd64.deb ./autopsy_4.19.2-1_amd64.deb

--- a/install_debian_autopsy_4.19.2.sh
+++ b/install_debian_autopsy_4.19.2.sh
@@ -9,7 +9,10 @@ fi
 
 export DEBIAN_FRONTEND=noninteractive
 
-cd "$(mktemp -d -t autopsy_installer-XXXXXXXXXX)"
+INSTALLER_TMPDIR="$(mktemp -d -t autopsy_installer-XXXXXXXXXX)"
+trap 'rm -rf "$INSTALLER_TMPDIR"' EXIT
+
+cd "$INSTALLER_TMPDIR"
 
 apt -y update
 apt -y install curl gnupg

--- a/test_debian_install_script_docker.sh
+++ b/test_debian_install_script_docker.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+version=4.19.2
+script="install_debian_autopsy_${version}.sh"
+
+docker run --rm -it -v "${PWD}/$script:/workdir/$script" -w /workdir debian:stable /bin/bash "$script"


### PR DESCRIPTION
Still have to upload the version of the .deb package from the action that will run when I open this PR to the releases page, and then the install script should work in one go on debian. That will be quite an improvement on the current state of installing autopsy in debian/ubuntu.